### PR TITLE
Update Storybook to match configuration in other repositories

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,24 +1,35 @@
-<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro%3A400%2C600%2C700%7CRoboto+Condensed&amp;ver=4.9.8" type="text/css" media="all">
-<link rel="stylesheet" href="//unpkg.com/@creativecommons/vocabulary/css/vocabulary.css">
+<link
+  rel="stylesheet"
+  href="//fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700|Roboto+Condensed:400,700|Fira+Code:400"
+  type="text/css"
+  media="all">
+<link
+  rel="stylesheet"
+  href="//unpkg.com/@creativecommons/vocabulary/css/vocabulary.css"
+  type="text/css"
+  media="all">
 
 <style>
   html {
-    background-color: unset;
-
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
-  }
-
-  body {
-    font-family: Roboto Condensed;
+    background-color: unset !important;
   }
 
   body.sb-show-main {
-    padding: 0.5em;
+    font-family: "Source Sans Pro", sans-serif;
     box-sizing: border-box;
+    padding: 0.5em;
   }
 
-  p:first-of-type {
-    margin-top: 0;
+  .sbdocs.sbdocs-ul {
+    list-style: unset;
+  }
+
+  .sbdocs.sbdocs-preview {
+    background-color: #f5f5f5;
+  }
+
+  .monospace {
+    font-family: "Fira Code", monospace;
+    font-size: 14px;
   }
 </style>

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -13,7 +13,7 @@ export default create({
 
   // Rows of controls
   barTextColor: 'rgb(73, 80, 87)',
-  barSelectedColor: 'rgb(0, 0, 0)',
+  barSelectedColor: 'rgb(251, 119, 41)',
   barBg: 'rgb(255, 255, 255)',
 
   // Typography

--- a/.storybook/welcome.stories.js
+++ b/.storybook/welcome.stories.js
@@ -19,7 +19,7 @@ export const Welcome = () => `
     Fonts is a collection of typefaces that lend personality to the web facing Creative Commons.
   </p>
   <a href="https://github.com/creativecommons/fonts" target="_blank">
-    <button class="button is-primary">GitHub repository</button>
+    <button class="button small is-primary">GitHub repository</button>
   </a>
 </div>
 `


### PR DESCRIPTION
**Description**
Updates the Storybook theme, header content and welcome story to match the repo Vocabulary.

**Type of PR** 
This PR is a hotfix.

**Checklist:**
<!-- Replace  the [ ] with [x] to check the boxes --> 
- [x] My pull request has a descriptive title (not a vague title like "Update `index.md`").
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

**Legal**
By submitting this PR, I agree to abide by the terms of the Developer 
Certificate of Origin.

<details>
<summary>Developer Certificate of Origin</summary>

Developer Certificate of Origin<br>
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.<br>
1 Letterman Drive<br>
Suite D4700<br>
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</details>
