### PR TITLE
`font-display: swap` for `@font-face` declarations

### DIFF
--- a/src/styles/font_face.scss
+++ b/src/styles/font_face.scss
@@ -2,6 +2,7 @@
   font-family: $font-name;
   font-style: normal;
   font-weight: $font-weight;
+  font-display: swap;
   src: url('../fonts/' + $font-file + '.woff2') format('woff2'),
   url('../fonts/' + $font-file + '.woff') format('woff'),
   url('../fonts/' + $font-file + '.otf') format('opentype');

--- a/tests/unit/font_face.scss
+++ b/tests/unit/font_face.scss
@@ -9,6 +9,7 @@
         font-family: "Helvetica Neue";
         font-style: normal;
         font-weight: 400;
+        font-display: swap;
         src: url('../fonts/HelveticaNeue-Regular.woff2') format('woff2'),
         url('../fonts/HelveticaNeue-Regular.woff') format('woff'),
         url('../fonts/HelveticaNeue-Regular.otf') format('opentype');


### PR DESCRIPTION
Adds `font-display: swap` for `@font-face` declarations to improve font performance.
See: https://developers.google.com/web/updates/2016/02/font-display#swap

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
